### PR TITLE
updated to the latest ns-options

### DIFF
--- a/dumpdb.gemspec
+++ b/dumpdb.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency("assert")
-  gem.add_dependency("scmd", ["~>1.1"])
-  gem.add_dependency("ns-options", ["~>0.4"])
+  gem.add_dependency("scmd", ["~>2.0"])
+  gem.add_dependency("ns-options", ["1.0.0.rc1"])
 end

--- a/lib/dumpdb.rb
+++ b/lib/dumpdb.rb
@@ -21,11 +21,12 @@ module Dumpdb
         option 'restore_cmds', Settings::CmdList,      :default => []
       end
 
-      # TODO: can move this to SettingsMethods if ns-option uses anonymous modules
-      def settings; self.class.settings; end
-
       extend  SettingsDslMethods
       include SettingsMethods
+
+      def self.inherited(subclass)
+        subclass.settings.apply(self.settings.to_hash)
+      end
 
     end
   end
@@ -44,6 +45,8 @@ module Dumpdb
   end
 
   module SettingsMethods
+
+    def settings; self.class.settings; end
 
     def ssh;       @ssh       ||= settings.ssh.value(self);       end
     def databases; @databases ||= settings.databases.value(self); end

--- a/test/script_tests.rb
+++ b/test/script_tests.rb
@@ -5,7 +5,6 @@ module Dumpdb
   class ScriptTests < Assert::Context
     desc "the main script mixin"
     setup do
-      # TODO: fix ns-options so you can set this to LocalScript and it won't fail
       @script = LocalScript.new
     end
     subject { @script }
@@ -111,6 +110,19 @@ module Dumpdb
       assert_not_empty FakeCmdRunner.cmds
       assert_equal 7, FakeCmdRunner.cmds.size
       assert_equal "a restore cmd", FakeCmdRunner.cmds[-3]
+    end
+
+  end
+
+  class InheritedTests < ScriptTests
+    desc "when inherited"
+    setup do
+      @a_remote_script     = RemoteScript.new
+      @a_sub_remote_script = Class.new(RemoteScript).new
+    end
+
+    should "pass its definition values to any subclass" do
+      assert_equal @a_remote_script.ssh, @a_sub_remote_script.ssh
     end
 
   end


### PR DESCRIPTION
This version fixes some issues where inherited options don't get the
definition from the superclass definition.  This was breaking some
stuff and causing me to have to do some dirty hacks.

With the move to this version, I can remove the hacks and what-not.

This also upgrades to the latest scmd.
