### PR TITLE
escape backslashes and double quotes in remote dump cmds run using ssh

### DIFF
--- a/lib/dumpdb/settings.rb
+++ b/lib/dumpdb/settings.rb
@@ -62,6 +62,7 @@ module Dumpdb::Settings
     def value(script, placeholder_vals={})
       val = super(script, script.source.to_hash.merge(placeholder_vals))
       if script.ssh?
+        val = val.gsub("\\", "\\\\\\").gsub('"', '\"')
         val = "ssh -A #{script.ssh_opts} #{script.ssh} \"#{val}\""
       end
       val

--- a/test/settings_tests.rb
+++ b/test/settings_tests.rb
@@ -126,6 +126,20 @@ module Dumpdb
       assert_equal "this is the local db: devdb", cmd_val
     end
 
+    should "not escape any double-quotes in the cmds" do
+      orig_cmd    = "do_something --value=\"a_val\""
+      cmd_val = Settings::DumpCmd.new(Proc.new { orig_cmd }).value(@script)
+
+      assert_equal orig_cmd, cmd_val
+    end
+
+    should "not escape any backslashes in the cmds" do
+      orig_cmd    = "do \\something"
+      cmd_val = Settings::DumpCmd.new(Proc.new { orig_cmd }).value(@script)
+
+      assert_equal orig_cmd, cmd_val
+    end
+
   end
 
   class RemoteDumpCmdTests < DumpCmdTests
@@ -138,6 +152,33 @@ module Dumpdb
     should "build the cmds to run remtoely using ssh" do
       exp_cmd_str = "ssh -A #{@script.ssh_opts} #{@script.ssh} \"echo hello\""
       cmd_val = Settings::DumpCmd.new(@cmd_str).value(@script)
+
+      assert_equal exp_cmd_str, cmd_val
+    end
+
+    should "escape any double-quotes in the cmds" do
+      orig_cmd    = "do_something --value=\"a_val\""
+      exp_esc_cmd = "do_something --value=\\\"a_val\\\""
+      exp_cmd_str = "ssh -A #{@script.ssh_opts} #{@script.ssh} \"#{exp_esc_cmd}\""
+      cmd_val = Settings::DumpCmd.new(Proc.new { orig_cmd }).value(@script)
+
+      assert_equal exp_cmd_str, cmd_val
+    end
+
+    should "escape any backslashes in the cmds" do
+      orig_cmd    = "do \\something"
+      exp_esc_cmd = "do \\\\something"
+      exp_cmd_str = "ssh -A #{@script.ssh_opts} #{@script.ssh} \"#{exp_esc_cmd}\""
+      cmd_val = Settings::DumpCmd.new(Proc.new { orig_cmd }).value(@script)
+
+      assert_equal exp_cmd_str, cmd_val
+    end
+
+    should "escape any backslashes before double-quotes in the cmds" do
+      orig_cmd    = "do \\something --value=\"a_val\""
+      exp_esc_cmd = "do \\\\something --value=\\\"a_val\\\""
+      exp_cmd_str = "ssh -A #{@script.ssh_opts} #{@script.ssh} \"#{exp_esc_cmd}\""
+      cmd_val = Settings::DumpCmd.new(Proc.new { orig_cmd }).value(@script)
 
       assert_equal exp_cmd_str, cmd_val
     end


### PR DESCRIPTION
Because the ssh command wraps the original cmd in double quotes, you
need to escape any backslashes and double quotes when building ssh
dump cmds.
