### PR TITLE
remove ns-options as a dependency

### DIFF
--- a/dumpdb.gemspec
+++ b/dumpdb.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.15.1"])
 
-  gem.add_dependency("scmd",       ["~> 3.0.1"])
-  gem.add_dependency("ns-options", ["~> 1.1.6"])
+  gem.add_dependency("much-plugin", ["~> 0.2.0"])
+  gem.add_dependency("scmd",        ["~> 3.0.2"])
+
 end

--- a/lib/dumpdb.rb
+++ b/lib/dumpdb.rb
@@ -1,59 +1,59 @@
-require 'ns-options'
+require 'much-plugin'
 require 'dumpdb/version'
 require 'dumpdb/settings'
 require 'dumpdb/db'
 require 'dumpdb/runner'
 
 module Dumpdb
+  include MuchPlugin
 
-  class BadDatabaseName < RuntimeError; end
+  plugin_included do
+    extend  ClassMethods
+    include InstanceMethods
 
-  def self.included(receiver)
-    receiver.class_eval do
-      include NsOptions
-      options :settings do
-        option 'ssh',          Settings::Ssh,          :default => ''
-        option 'dump_file',    Settings::DumpFile,     :default => ''
-        option 'source',       Settings::SourceTarget, :default => {}
-        option 'target',       Settings::SourceTarget, :default => {}
-        option 'dump_cmds',    Settings::CmdList,      :default => []
-        option 'restore_cmds', Settings::CmdList,      :default => []
-      end
-
-      extend  SettingsDslMethods
-      include SettingsMethods
-
-      def self.inherited(subclass)
-        subclass.settings.apply(self.settings.to_hash)
-      end
-
+    def self.inherited(subclass)
+      subclass.settings = self.settings
     end
-  end
-
-  module SettingsDslMethods
-
-    def ssh(&block);       settings.ssh       = Settings::Ssh.new(block);          end
-    def dump_file(&block); settings.dump_file = Settings::DumpFile.new(block);     end
-    def source(&block);    settings.source    = Settings::SourceTarget.new(block); end
-    def target(&block);    settings.target    = Settings::SourceTarget.new(block); end
-
-    def dump(&block);    settings.dump_cmds    << Settings::DumpCmd.new(block);    end
-    def restore(&block); settings.restore_cmds << Settings::RestoreCmd.new(block); end
 
   end
 
-  module SettingsMethods
+  module ClassMethods
+
+    def ssh(&block);       settings[:ssh]       = Settings::Ssh.new(block);          end
+    def dump_file(&block); settings[:dump_file] = Settings::DumpFile.new(block);     end
+    def source(&block);    settings[:source]    = Settings::SourceTarget.new(block); end
+    def target(&block);    settings[:target]    = Settings::SourceTarget.new(block); end
+
+    def dump(&block);    settings[:dump_cmds]    << Settings::DumpCmd.new(block);    end
+    def restore(&block); settings[:restore_cmds] << Settings::RestoreCmd.new(block); end
+
+    def settings
+      @settings ||= {
+        :ssh          => Settings::Ssh.new(''),
+        :dump_file    => Settings::DumpFile.new(''),
+        :source       => Settings::SourceTarget.new({}),
+        :target       => Settings::SourceTarget.new({}),
+        :dump_cmds    => Settings::CmdList.new([]),
+        :restore_cmds => Settings::CmdList.new([])
+      }
+    end
+
+    def settings=(value); @settings = value; end
+
+  end
+
+  module InstanceMethods
+
+    def ssh;       @ssh       ||= settings[:ssh].value(self);       end
+    def dump_file; @dump_file ||= settings[:dump_file].value(self); end
+    def source;    @source    ||= settings[:source].value(self);    end
+    def target;    @target    ||= settings[:target].value(self);    end
+
+    def dump_cmds;     @dump_cmds     ||= settings[:dump_cmds].value(self);      end
+    def restore_cmds;  @restore_cmds  ||= settings[:restore_cmds].value(self);   end
+    def copy_dump_cmd; @copy_dump_cmd ||= Settings::CopyDumpCmd.new.value(self); end
 
     def settings; self.class.settings; end
-
-    def ssh;       @ssh       ||= settings.ssh.value(self);       end
-    def dump_file; @dump_file ||= settings.dump_file.value(self); end
-    def source;    @source    ||= settings.source.value(self);    end
-    def target;    @target    ||= settings.target.value(self);    end
-
-    def dump_cmds;     @dump_cmds     ||= settings.dump_cmds.value(self);        end
-    def restore_cmds;  @restore_cmds  ||= settings.restore_cmds.value(self);     end
-    def copy_dump_cmd; @copy_dump_cmd ||= Settings::CopyDumpCmd.new.value(self); end
 
   end
 
@@ -88,5 +88,7 @@ module Dumpdb
   def after_teardown(*args);   end
   def before_cmd_run(*args);   end
   def after_cmd_run(*args);    end
+
+  BadDatabaseName = Class.new(RuntimeError)
 
 end

--- a/test/unit/dumpdb_tests.rb
+++ b/test/unit/dumpdb_tests.rb
@@ -33,18 +33,13 @@ module Dumpdb
     should have_imeths :before_dump, :before_copy_dump, :before_restore
     should have_imeths :after_dump,  :after_copy_dump,  :after_restore
 
-    should "store its settings using ns-options" do
-      assert_kind_of NsOptions::Namespace, subject.class.settings
-      assert_same subject.class.settings, subject.settings
-    end
-
     should "store off the settings for the script" do
-      assert_kind_of Settings::Ssh,          subject.settings.ssh
-      assert_kind_of Settings::DumpFile,     subject.settings.dump_file
-      assert_kind_of Settings::SourceTarget, subject.settings.source
-      assert_kind_of Settings::SourceTarget, subject.settings.target
-      assert_kind_of Settings::CmdList,      subject.settings.dump_cmds
-      assert_kind_of Settings::CmdList,      subject.settings.restore_cmds
+      assert_kind_of Settings::Ssh,          subject.settings[:ssh]
+      assert_kind_of Settings::DumpFile,     subject.settings[:dump_file]
+      assert_kind_of Settings::SourceTarget, subject.settings[:source]
+      assert_kind_of Settings::SourceTarget, subject.settings[:target]
+      assert_kind_of Settings::CmdList,      subject.settings[:dump_cmds]
+      assert_kind_of Settings::CmdList,      subject.settings[:restore_cmds]
     end
 
   end


### PR DESCRIPTION
This is part of getting this gem working in modern ruby versions.
We are moving away from using ns-options as a dependency b/c it
has performance issues when accessing options and on top of that
its API hasn't proven to be especially useful over a struct-like
class.

This removes the `:settings` options group.  Since it was just
handling option storage, I replaced it with a basic hash with
the appropriate defaults set for each option value.

I also brought in much-plugin since this is a mixin with an
included hook.

@jcredding ready for review.
